### PR TITLE
Explityly specify -t dna to seqkit to ensure complements

### DIFF
--- a/subworkflows/local/read_transform.nf
+++ b/subworkflows/local/read_transform.nf
@@ -10,7 +10,7 @@ def modules = params.modules.clone()
 //
 def seqkit_seq_options  = modules['seqkit_seq']
 if (params.read_transform != null && params.read_transform.contains('complement')) {
-    seqkit_seq_options.args += " -p"
+    seqkit_seq_options.args += " -p -t dna"
 }
 if (params.read_transform != null && params.read_transform.contains('reverse')) {
     seqkit_seq_options.args += " -r"


### PR DESCRIPTION
When a fastq has a missing 1st entry (due to short reads and trimming) `seqkit seq` infers that the type of sequences in the file is "unlimit" rather than "dna": https://bioinf.shenwei.me/seqkit/usage/#seq

"unlimit" type sequences cannot be complemented and the files currently returned by `--read_transform "reverse_complement"` are just reversed. This will mean no reads match template libraries for quantification.

Specify `-t dna` or `--seq-type  dna` will fix.  This could  limits quants from working with RNA sequences - is this a potential issue?