### PR TITLE
fix primer trimming with cutadapt to produce untrimmed reads

### DIFF
--- a/modules/local/cutadapt/main.nf
+++ b/modules/local/cutadapt/main.nf
@@ -23,7 +23,7 @@ process CUTADAPT {
 
     output:
     tuple val(meta), path('*_trimmed{,_1,_2}.fastq.gz')  , emit: reads
-    tuple val(meta), path('*_untrimmed_{1,2}.fastq.gz'), emit: untrimmed_reads, optional: true
+    tuple val(meta), path('*_untrimmed{,_1,_2}.fastq.gz'), emit: untrimmed_reads, optional: true
     tuple val(meta), path('*.log')               , emit: log
     tuple val(meta), path('*.json')              , emit: json
     path '*.version.txt'                         , emit: version
@@ -33,7 +33,8 @@ process CUTADAPT {
     def prefix         = options.suffix ? "${meta.id}${options.suffix}" : "${meta.id}"
     def trimmed        = meta.single_end ? "-o ${prefix}_trimmed.fastq.gz" : "-o ${prefix}_trimmed_1.fastq.gz -p ${prefix}_trimmed_2.fastq.gz"
     def untrimmed_cmd  = meta.single_end ? "--untrimmed-output ${prefix}_untrimmed.fastq.gz" : "--untrimmed-output ${prefix}_untrimmed_1.fastq.gz --untrimmed-paired-output ${prefix}_untrimmed_2.fastq.gz"
-    def untrimmed      = options.untrimmed ? untrimmed_cmd : ''
+    def untrimmed      = params.options.untrimmed ? untrimmed_cmd : ''
+
     """
     cutadapt \\
         --cores $task.cpus \\


### PR DESCRIPTION
Update primer trimming to fix the generation of untrimmed reads.